### PR TITLE
agrego documentación de la función get

### DIFF
--- a/pyeph/get/handler.py
+++ b/pyeph/get/handler.py
@@ -36,8 +36,6 @@ def get(data: str, *args, **kwargs):
 
 ------------------------------ENGLISH DOCSTRING-------------------------------------
 
-	Esta función permite obtener los resultados de la Encuesta Permanente de Hogares (EPH) 2016-act.
-
 	This function allows to get the results of "Encuesta Permanente de Hogares (EPH) 2016-act.",
 	permanent household survey, in Argentina provided by INDEC.
 
@@ -62,7 +60,7 @@ def get(data: str, *args, **kwargs):
 				period to request.
 
 	Returns:
-		pandas.DataFrame: Devuelve una estructura de datos columnar de pandas con los datos solicitados.
+		pandas.DataFrame: Returns a pandas data structure with the requested data. 
 	"""
 
 	

--- a/pyeph/get/handler.py
+++ b/pyeph/get/handler.py
@@ -6,6 +6,66 @@ from .equivalent_adult import EquivalentAdult
 from .mautic import Mautic
 
 def get(data: str, *args, **kwargs):
+	"""
+	------------------------------ENGLISH BELOW-------------------------------------
+	Esta función permite obtener los resultados de la Encuesta Permanente de Hogares (EPH) 2016-act. provista
+	por INDEC.
+
+	Args:
+		data (str): solicitud de los datos que necesitas obtener. Posibles argumentos: 'microdata', 'eph',
+		'canastas', 'adulto-equivalente', 'mautic'.
+
+	*args:
+		'eph':
+			year : str
+				año de la eph
+			freq : str
+				tipo de frecuencia "trimestral" u "onda" 
+			period : list
+				periodo que se desea consultar
+			base_type : str, optional
+				tipo de base a solicitar "individual", "hogar"
+		'mautic':
+			year : str
+				año de la eph
+			period : list
+				periodo que se desea consultar
+
+	Returns:
+		pandas.DataFrame: Devuelve una estructura de datos columnar de pandas con los datos solicitados.
+
+------------------------------ENGLISH DOCSTRING-------------------------------------
+
+	Esta función permite obtener los resultados de la Encuesta Permanente de Hogares (EPH) 2016-act.
+
+	This function allows to get the results of "Encuesta Permanente de Hogares (EPH) 2016-act.",
+	permanent household survey, in Argentina provided by INDEC.
+
+	Args:
+		data (str): request about the data to adquire. Possible arguments: 'microdata', 'eph',
+		'canastas', 'adulto-equivalente', 'mautic'.
+
+	*args:
+		'eph':
+			year : str
+				year of eph
+			freq : str
+				frequency about data "trimestral" u "onda" 
+			period : list
+				period to request.
+			base_type : str, optional
+				base type to request "individual", "hogar"
+		'mautic':
+			year : str
+				year of eph
+			period : list
+				period to request.
+
+	Returns:
+		pandas.DataFrame: Devuelve una estructura de datos columnar de pandas con los datos solicitados.
+	"""
+
+	
 	handles = {
 		'microdata': MicroData,
 		'eph': MicroData,


### PR DESCRIPTION
Entiendo que esta es la función principal para el get, la estaba usando y me percaté que no estaba documentada y me pareció que puede ser molesto para un usuario casual no saber que se está solicitando o tener que ir y volver en la documentación.