### PR TITLE
Actualiza el título del working paper citado en la documentación

### DIFF
--- a/docs/md/comparability.md
+++ b/docs/md/comparability.md
@@ -36,7 +36,7 @@ individuos = pyeph.comparability_bridge(individuos, base_hogar=hogares)
 
 Las reglas de reconstrucción están documentadas y validadas en:
 
-> Tessmer, G. y Boggiano, B. (2026). *From Breaks to Bridges: Harmonizing the New and Old Permanent Household Survey for Consistent Labor Market Series*. SSRN Working Paper 6597399. <https://papers.ssrn.com/abstract=6597399>
+> Tessmer, G. y Boggiano, B. (2026). *From Breaks to Bridges: An Architecture for Survey Redesigns That Expand Conceptual Scope*. SSRN Working Paper 6597399. <https://papers.ssrn.com/abstract=6597399>
 
 > Observatorio Económico Social UNR. *Manual Metodológico EPH – Observatorio*, Parte A. <https://hdl.handle.net/2133/33253>
 

--- a/pyeph/tools/comparability.py
+++ b/pyeph/tools/comparability.py
@@ -11,9 +11,9 @@ la serie histórica.
 
 Referencias
 -----------
-- Tessmer, G. y Boggiano, B. (2026). "From Breaks to Bridges: Harmonizing
-  the New and Old Permanent Household Survey for Consistent Labor Market
-  Series". SSRN Working Paper 6597399.
+- Tessmer, G. y Boggiano, B. (2026). "From Breaks to Bridges: An
+  Architecture for Survey Redesigns That Expand Conceptual Scope". SSRN
+  Working Paper 6597399.
 - Observatorio Económico Social UNR. "Manual Metodológico EPH –
   Observatorio", Parte A. https://hdl.handle.net/2133/33253
   (datasets: https://doi.org/10.57715/UNR/BL85Z8).


### PR DESCRIPTION
Corrige el título del working paper que se cita como referencia metodológica de `comparability_bridge()`.

Tras la respuesta del editor, el título del paper cambió. El que quedó publicado en la documentación (v1.7.0) es el anterior:

- **Antes:** *From Breaks to Bridges: Harmonizing the New and Old Permanent Household Survey for Consistent Labor Market Series*
- **Ahora:** *From Breaks to Bridges: An Architecture for Survey Redesigns That Expand Conceptual Scope*

El DOI (`10.2139/ssrn.6597399`), el número de SSRN y la URL no cambian, así que el enlace sigue resolviendo igual.

Son 4 líneas en 2 archivos (`docs/md/comparability.md` y el docstring de `pyeph/tools/comparability.py`). **No toca la lógica del puente ni los tests.**

Mientras tanto, la documentación en readthedocs sigue mostrando el título viejo, por eso la corrección.

¡Gracias!
